### PR TITLE
Support Python 3.8 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ This will install the following modules:
 * `ezgmail`
 * `ezsheets`
 * `pyinputplus`
-* `pillow==6.0.0`
+* `pillow==7.1.2`
 * `pyautogui`
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'ezgmail',
         'ezsheets',
         'pyinputplus',
-        'pillow==6.0.0',
+        'pillow==7.1.2',
         'pyautogui',
     ],
     keywords="automate boring stuff python",


### PR DESCRIPTION
Replaces and closes https://github.com/asweigart/automateboringstuff/pull/1. 

This is needed to support Python 3.8 on Windows, because Pillow 6.0.0 predated Python 3.8 and so doesn't have wheels available, meaning Windows will attempt to compile from source and fall over like in https://github.com/python-pillow/Pillow/issues/4610.

https://pillow.readthedocs.io/en/stable/installation.html shows Pillow 6.2.1 or later supports Python 3.8.